### PR TITLE
Code sig ver note for Outset download

### DIFF
--- a/outset/outset.download.recipe
+++ b/outset/outset.download.recipe
@@ -3,7 +3,8 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release of Outset from Github.</string>
+    <string>Downloads the current release of Outset from Github.
+    Note: Code signature verification is not possible for Outset at this time.</string>
     <key>Identifier</key>
     <string>com.github.grahamgilbert.download.outset</string>
     <key>Input</key>


### PR DESCRIPTION
Added note about code signature verification for the Outset download recipe:

```
pkgutil --check-signature /Users/USERNAME/Downloads/outset-2.0.3.pkg 
Package "outset-2.0.3.pkg":
   Status: no signature
```
